### PR TITLE
Fix with_items syntax

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -81,7 +81,7 @@
   template:
     src: "{{ item.template|default('site.j2') }}"
     dest: "{{nginx_dir}}/sites-available/{{item.server.name}}"
-  with_items:  nginx_sites
+  with_items:  "{{ nginx_sites }}"
   when: nginx_sites|lower != 'none'
 
 


### PR DESCRIPTION
Otherwise Ansible 2.2.0 throws an error "unicode object has no attribute 'server'".