### PR TITLE
Upgraded: Notation to Ansible 2.2

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,12 +2,12 @@
 
 - name:    restart nginx
   service: name=nginx state=restarted
-  sudo:    yes
+  become:  yes
 
 - name:    reload nginx
   service: name=nginx state=reloaded
-  sudo:    yes
+  become:  yes
 
 - name:    restart monit
   service: name=monit state=restarted
-  sudo:    yes
+  become:  yes

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -25,12 +25,12 @@
     mode: 0644
   notify:
     - restart nginx
-  when: have_systemd.stdout == "true"
+  when: "{{ have_systemd.stdout == 'true' }}"
 
 
 - name: Nginx Configure | Reload scripts if using systemd
   shell: "systemctl daemon-reload"
-  when: have_systemd.stdout == "true"
+  when: "{{ have_systemd.stdout == 'true' }}"
 
 
 - name: Nginx Configure | Register Nginx as a service
@@ -42,7 +42,7 @@
 - name: Nginx Configure | Install the nxensite and nxdissite scripts
   template:
     src: "{{item}}.j2"
-    dest: "/usr/sbin/{{item}}"
+    dest: "/usr/sbin/{{ item }}"
     owner: root
     group: root
     mode: 0755
@@ -54,7 +54,7 @@
 - name: Nginx Configure | Make sure the mime.types file is up to date
   copy:
     src: mime.types
-    dest: "{{nginx_dir}}/mime.types"
+    dest: "{{ nginx_dir }}/mime.types"
     owner: root
     group: root
     mode: 0644
@@ -65,7 +65,7 @@
 - name: Nginx Configure | Make sure the Nginx configuration is updated
   template:
     src: nginx.conf.j2
-    dest: "{{nginx_dir}}/nginx.conf"
+    dest: "{{ nginx_dir }}/nginx.conf"
     owner: root
     group: root
     mode: 0644
@@ -80,9 +80,9 @@
 - name: Nginx Configure | Update the configurations for the sites inventory
   template:
     src: "{{ item.template|default('site.j2') }}"
-    dest: "{{nginx_dir}}/sites-available/{{item.server.name}}"
-  with_items:  nginx_sites
-  when: nginx_sites|lower != 'none'
+    dest: "{{ nginx_dir }}/sites-available/{{ item.server.name }}"
+  with_items: "{{ nginx_sites }}"
+  when: "{{ nginx_sites|lower != 'none' }}"
 
 
 # example
@@ -96,21 +96,21 @@
 
 - name: Nginx Configure | Enable sites
   file:
-    path:  "{{nginx_dir}}/sites-enabled/{{item.server.name}}"
-    src:   "{{nginx_dir}}/sites-available/{{item.server.name}}"
+    path:  "{{ nginx_dir }}/sites-enabled/{{ item.server.name }}"
+    src:   "{{ nginx_dir }}/sites-available/{{ item.server.name }}"
     state: link
   with_items: "{{ nginx_sites }}"
-  when:       nginx_sites|lower != 'none' and nginx_enabled_sites|lower != 'none' and item.server.name == "{% for e in nginx_enabled_sites %}{% if item.server is defined and item.server.name is defined and e == item.server.name %}{{item.server.name}}{% endif %}{% endfor %}"
+  when:       "{{ nginx_sites|lower != 'none' and nginx_enabled_sites|lower != 'none' and item.server.name in nginx_enabled_sites }}"
   notify:
     - reload nginx
 
 
 - name: Nginx Configure | Ensure sites not enabled are disabled
   file:
-    path:  "{{nginx_dir}}/sites-enabled/{{item.server.name}}"
+    path:  "{{ nginx_dir }}/sites-enabled/{{ item.server.name }}"
     state: absent
   with_items: "{{ nginx_sites }}"
-  when:       nginx_sites|lower != 'none' and ( nginx_enabled_sites|lower == 'none' or item.server.name != "{% for e in nginx_enabled_sites %}{% if item.server is defined and item.server.name is defined and e == item.server.name %}{{item.server.name}}{% endif %}{% endfor %}" )
+  when:       "{{ nginx_sites|lower != 'none' and ( nginx_enabled_sites|lower == 'none' or item.server.name not in nginx_enabled_sites ) }}"
   notify:
     - reload nginx
 
@@ -120,7 +120,7 @@
   apt:
     pkg:   "monit"
     state: present
-  when: nginx_monit_protection == true or nginx_monit_protection == 'True'
+  when: "{{ nginx_monit_protection == true or nginx_monit_protection == 'True' }}"
 
 - name: Nginx Configure | Create the nginx monit service file when monit protection enabled
   template:
@@ -128,11 +128,11 @@
     dest: /etc/monit/conf.d/nginx
   notify:
     - restart monit
-  when: nginx_monit_protection == true or nginx_monit_protection == 'True'
+  when: "{{ nginx_monit_protection == true or nginx_monit_protection == 'True' }}"
 
 - name: Nginx Configure | Remove the nginx monit service file when monit protection disabled
   file:
     path:  /etc/monit/conf.d/nginx
     state: absent
-  when: nginx_monit_protection == false or nginx_monit_protection == 'False'
+  when: "{{ nginx_monit_protection == false or nginx_monit_protection == 'False' }}"
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -5,59 +5,59 @@
 # If Nginx or php5-fpm  running stop them
 - name: Nginx Install | Shut down nginx if it is running
   shell: "pkill nginx || echo ''"
-  when: old_user_checksum.stdout != new_user_checksum.stdout
+  when: "{{ old_user_checksum.stdout != new_user_checksum.stdout }}"
 
 - name: Nginx Install | Shut down php-fpm if it is running
   shell: "pkill php || echo ''"
-  when: old_user_checksum.stdout != new_user_checksum.stdout
+  when: "{{ old_user_checksum.stdout != new_user_checksum.stdout }}"
 
 
 # Nginx User/Group
 - name: Nginx Install | Make sure the nginx group is present
   group:
-    gid: "{{nginx_gid}}"
-    name: "{{nginx_group}}"
+    gid: "{{ nginx_gid }}"
+    name: "{{ nginx_group }}"
     state: present
-  when: old_user_checksum.stdout != new_user_checksum.stdout
+  when: "{{ old_user_checksum.stdout != new_user_checksum.stdout }}"
 
 - name: Nginx Install | Make sure the www directory is present
   file:
-    path: "{{nginx_www_dir}}"
+    path: "{{ nginx_www_dir }}"
     state: directory
-  when: old_user_checksum.stdout != new_user_checksum.stdout
+  when: "{{ old_user_checksum.stdout != new_user_checksum.stdout }}"
 
 - name: Nginx Install | Make sure the nginx user is present
   user:
-    name: "{{nginx_user}}"
-    uid: "{{nginx_uid}}"
-    group: "{{nginx_group}}"
+    name: "{{ nginx_user }}"
+    uid: "{{ nginx_uid }}"
+    group: "{{ nginx_group }}"
     comment: "Nginx user"
-    home: "{{nginx_www_dir}}"
+    home: "{{ nginx_www_dir }}"
     shell: /bin/false
     state: present
     system: yes
-  when: old_user_checksum.stdout != new_user_checksum.stdout
+  when: "{{ old_user_checksum.stdout != new_user_checksum.stdout }}"
 
 - name: Nginx Install | Set the right directory permissions for the www directory
   file:
-    path: "{{nginx_www_dir}}"
-    owner: "{{nginx_user}}"
-    group: "{{nginx_group}}"
+    path: "{{ nginx_www_dir }}"
+    owner: "{{ nginx_user }}"
+    group: "{{ nginx_group }}"
     mode: 0755
     state: directory
-  when: old_user_checksum.stdout != new_user_checksum.stdout
+  when: "{{ old_user_checksum.stdout != new_user_checksum.stdout }}"
 
 - name: Nginx Install | Set the right expiration on the nginx user
   shell: "chage -I -1 -E -1 -m -1 -M -1 -W -1 -E -1 {{nginx_user}} && grep {{nginx_user}} /etc/shadow"
-  sudo: yes
-  when: old_user_checksum.stdout != new_user_checksum.stdout
+  become:  yes
+  when: "{{ old_user_checksum.stdout != new_user_checksum.stdout }}"
 
 
 # Nginx directories
 
 - name: Nginx Install | Make sure the nginx directory exists
   file:
-    path: "{{nginx_dir}}"
+    path: "{{ nginx_dir }}"
     owner: root
     group: root
     mode: 0755
@@ -65,7 +65,7 @@
 
 - name: Nginx Install | Make sure the nginx log directory exists
   file:
-    path: "{{nginx_log_dir}}"
+    path: "{{ nginx_log_dir }}"
     owner: root
     group: root
     mode: 0755
@@ -73,7 +73,7 @@
 
 - name: Nginx Install | Make sure the sites-available, sites-enabled and conf.d directories exist
   file:
-    path: "{{nginx_dir}}/{{item}}"
+    path: "{{ nginx_dir }}/{{ item }}"
     owner: root
     group: root
     mode: 0755
@@ -86,7 +86,7 @@
 - name: Nginx Install | Make sure the Nginx build dependencies are installed
   apt:
     update_cache: yes
-    pkg: "{{item}}"
+    pkg: "{{ item }}"
     state: present
   with_items:
     - perl
@@ -101,9 +101,9 @@
 
 - name: Nginx Install | Clone the Nginx repo
   hg:
-    repo:     "{{nginx_repo}}"
-    dest:     "{{nginx_build_dir}}/nginx-repo"
-    revision: "{{nginx_revision}}"
+    repo:     "{{ nginx_repo }}"
+    dest:     "{{ nginx_build_dir }}/nginx-repo"
+    revision: "{{ nginx_revision }}"
     purge:    "yes"
 
 - name: Nginx Install | test for presence of configure script
@@ -121,7 +121,7 @@
     perl -pi -e "s/\"Server:.*CRLF/\"Server: {{nginx_server_string}}\" CRLF/g"             "src/http/ngx_http_header_filter_module.c" &&
     perl -pi -e "s/\"Server:[\t ]+nginx\"/\"Server: {{nginx_server_string}}\"/g"           "src/http/ngx_http_header_filter_module.c" &&
     perl -pi -e "s/\<hr\>\<center\>.*<\/center\>/<hr><center>Server Response<\/center>/g"  "src/http/ngx_http_special_response.c"
-  when: nginx_server_string != ""
+  when: "{{ nginx_server_string != '' }}"
 
 
 - name: Nginx Install | Compile the Nginx source
@@ -137,7 +137,7 @@
 
 - name: Nginx Install | Install the Nginx source
   shell: >
-    cd {{nginx_build_dir}}/nginx-repo && make install
+    cd {{ nginx_build_dir }}/nginx-repo && make install
   notify: restart nginx
 
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,12 +2,12 @@
 - include: 'prepare.yml'
 
 - include: 'install.yml'
-  when: old_checksum.stdout != new_checksum.stdout
+  when: "{{ old_checksum.stdout != new_checksum.stdout }}"
 
 - name: Nginx Configure | Set current checksum
-  command: "mv '{{nginx_dir}}/.nginx_compile_configuration.new' '{{nginx_dir}}/.nginx_compile_configuration'"
+  command: "mv '{{ nginx_dir }}/.nginx_compile_configuration.new' '{{ nginx_dir }}/.nginx_compile_configuration'"
 
 - name: Nginx Configure | Set current user checksum
-  command: "mv '{{nginx_dir}}/.nginx_user_configuration.new' '{{nginx_dir}}/.nginx_user_configuration'"
+  command: "mv '{{ nginx_dir }}/.nginx_user_configuration.new' '{{ nginx_dir }}/.nginx_user_configuration'"
 
 - include: 'configure.yml'

--- a/tasks/modules_configure/geoip_module.yml
+++ b/tasks/modules_configure/geoip_module.yml
@@ -2,34 +2,34 @@
 
 - name: Nginx Configure | Create geoip data directory for nginx when geoip module is enabled
   file:
-    path: "{{nginx_dir}}/geoip"
+    path: "{{ nginx_dir }}/geoip"
     owner: root
     group: root
     state: directory
     mode:  0755
-  when: nginx_modules.geoip_module is defined and ( nginx_modules.geoip_module == true or nginx_modules.geoip_module == 'True' )
+  when: "{{ nginx_modules.geoip_module is defined and ( nginx_modules.geoip_module == true or nginx_modules.geoip_module == 'True' ) }}"
 
 - name: Nginx Configure | Download geoip country data when geoip module is enabled
   get_url:
-    url:   "{{nginx_geoip_country_url}}"
-    dest:  "{{nginx_dir}}/geoip/GeoIP.dat.gz"
+    url:   "{{ nginx_geoip_country_url }}"
+    dest:  "{{ nginx_dir }}/geoip/GeoIP.dat.gz"
     force: no
-  when: nginx_modules.geoip_module is defined and ( nginx_modules.geoip_module == true or nginx_modules.geoip_module == 'True' )
+  when: "{{ nginx_modules.geoip_module is defined and ( nginx_modules.geoip_module == true or nginx_modules.geoip_module == 'True' ) }}"
 
 - name: Nginx Configure | Download geoip country data when geoip module is enabled
   get_url:
     url:   "{{nginx_geoip_city_url}}"
     dest:  "{{nginx_dir}}/geoip/GeoLiteCity.dat.gz"
     force: no
-  when: nginx_modules.geoip_module is defined and ( nginx_modules.geoip_module == true or nginx_modules.geoip_module == 'True' )
+  when: "{{ nginx_modules.geoip_module is defined and ( nginx_modules.geoip_module == true or nginx_modules.geoip_module == 'True' ) }}"
 
 - name: Nginx Configure | Extract geoip data when geoip module is enabled
   shell: >
-    gunzip -c "{{nginx_dir}}/geoip/GeoLiteCity.dat.gz" > "{{nginx_dir}}/geoip/GeoLiteCity.dat" &&
-    gunzip -c "{{nginx_dir}}/geoip/GeoIP.dat.gz"       > "{{nginx_dir}}/geoip/GeoIP.dat"
+    gunzip -c "{{ nginx_dir }}/geoip/GeoLiteCity.dat.gz" > "{{ nginx_dir }}/geoip/GeoLiteCity.dat" &&
+    gunzip -c "{{ nginx_dir }}/geoip/GeoIP.dat.gz"       > "{{ nginx_dir }}/geoip/GeoIP.dat"
   args:
-    creates:  "{{nginx_dir}}/geoip/GeoIP.dat"
-  when: nginx_modules.geoip_module is defined and ( nginx_modules.geoip_module == true or nginx_modules.geoip_module == 'True' )
+    creates:  "{{ nginx_dir }}/geoip/GeoIP.dat"
+  when: "{{ nginx_modules.geoip_module is defined and ( nginx_modules.geoip_module == true or nginx_modules.geoip_module == 'True' ) }}"
 
 - name: Nginx Configure | Set cron.monthly script to periodically update geoip data when geoip module is enabled
   template:
@@ -38,7 +38,7 @@
     owner: root
     group: root
     mode:  0755
-  when: nginx_modules.geoip_module is defined and ( nginx_modules.geoip_module == true or nginx_modules.geoip_module == 'True' )
+  when: "{{ nginx_modules.geoip_module is defined and ( nginx_modules.geoip_module == true or nginx_modules.geoip_module == 'True' ) }}"
 
 
 - name: Nginx Configure | Update geoip configuration file for nginx when geoip module is enabled
@@ -50,29 +50,27 @@
     mode:  0644
   notify:
     - reload nginx
-  when: nginx_modules.geoip_module is defined and ( nginx_modules.geoip_module == true or nginx_modules.geoip_module == 'True' )
-
-
+  when: "{{ nginx_modules.geoip_module is defined and ( nginx_modules.geoip_module == true or nginx_modules.geoip_module == 'True' ) }}"
 
 
 - name: Nginx Configure | Remove cron.monthly geoip update script when geoip module is disabled
   file:
     path:    "/etc/cron.monthly/geoip_update"
     state:   absent
-  when: nginx_modules.geoip_module is not defined or nginx_modules.geoip_module == false or nginx_modules.geoip_module == 'False'
+  when: "{{ nginx_modules.geoip_module is not defined or nginx_modules.geoip_module == false or nginx_modules.geoip_module == 'False' }}"
 
 - name: Nginx Configure | Remove nginx geoip directory and files when geoip module is disabled
   file:
-    path:  "{{nginx_dir}}/geoip"
+    path:  "{{ nginx_dir }}/geoip"
     state: absent
-  when: nginx_modules.geoip_module is not defined or nginx_modules.geoip_module == false or nginx_modules.geoip_module == 'False'
+  when: "{{ nginx_modules.geoip_module is not defined or nginx_modules.geoip_module == false or nginx_modules.geoip_module == 'False' }}"
 
 
 - name: Nginx Configure | Remove geoip configuration file for nginx when geoip module is disabled
   file:
-    path:  "{{nginx_dir}}/conf.d/geoip.conf"
+    path:  "{{ nginx_dir }}/conf.d/geoip.conf"
     state: absent
   notify:
     - reload nginx
-  when: nginx_modules.geoip_module is not defined or nginx_modules.geoip_module == false or nginx_modules.geoip_module == 'False'
+  when: "{{ nginx_modules.geoip_module is not defined or nginx_modules.geoip_module == false or nginx_modules.geoip_module == 'False' }}"
 

--- a/tasks/modules_configure/http_gzip_static_module.yml
+++ b/tasks/modules_configure/http_gzip_static_module.yml
@@ -4,18 +4,18 @@
 - name: Nginx Configure | Modules | Update the http_gzip_static_module configuration when enabled
   template:
     src: templates/modules/http_gzip_static.conf.j2
-    dest: "{{nginx_dir}}/conf.d/http_gzip_static.conf"
+    dest: "{{ nginx_dir }}/conf.d/http_gzip_static.conf"
     owner: root
     group: root
     mode: 0644
   notify:
     - reload nginx
-  when: nginx_modules.http_gzip_static_module is defined and ( nginx_modules.http_gzip_static_module == true or nginx_modules.http_gzip_static_module == 'True' )
+  when: "{{ nginx_modules.http_gzip_static_module is defined and ( nginx_modules.http_gzip_static_module == true or nginx_modules.http_gzip_static_module == 'True' ) }}"
 
 - name: Nginx Configure | Modules | Remove the http_gzip_static_module configuration when disabled
   file:
-    path: "{{nginx_dir}}/conf.d/http_gzip_static.conf"
+    path: "{{ nginx_dir }}/conf.d/http_gzip_static.conf"
     state: absent
   notify:
     - reload nginx
-  when: nginx_modules.http_gzip_static_module is not defined or nginx_modules.http_gzip_static_module == false or nginx_modules.http_gzip_static_module == 'False'
+  when: "{{ nginx_modules.http_gzip_static_module is not defined or nginx_modules.http_gzip_static_module == false or nginx_modules.http_gzip_static_module == 'False' }}"

--- a/tasks/modules_configure/http_realip_module.yml
+++ b/tasks/modules_configure/http_realip_module.yml
@@ -4,19 +4,19 @@
 - name: Nginx Configure | Modules | Update the http_realip_module configuration when enabled
   template:
     src: templates/modules/http_realip.conf.j2
-    dest: "{{nginx_dir}}/conf.d/http_realip.conf"
+    dest: "{{ nginx_dir }}/conf.d/http_realip.conf"
     owner: root
     group: root
     mode: 0644
   notify:
     - reload nginx
-  when: nginx_modules.http_realip_module is defined and ( nginx_modules.http_realip_module == true or nginx_modules.http_realip_module == 'True' )
+  when: "{{ nginx_modules.http_realip_module is defined and ( nginx_modules.http_realip_module == true or nginx_modules.http_realip_module == 'True' ) }}"
 
 - name: Nginx Configure | Modules | Remove the http_realip_module configuration when disabled
   file:
-    path: "{{nginx_dir}}/conf.d/http_realip.conf"
+    path: "{{ nginx_dir }}/conf.d/http_realip.conf"
     state: absent
   notify:
     - reload nginx
-  when: nginx_modules.http_realip_module is not defined or nginx_modules.http_realip_module == false or  nginx_modules.http_realip_module == 'False'
+  when: "{{ nginx_modules.http_realip_module is not defined or nginx_modules.http_realip_module == false or  nginx_modules.http_realip_module == 'False' }}"
 

--- a/tasks/modules_configure/http_stub_status_module.yml
+++ b/tasks/modules_configure/http_stub_status_module.yml
@@ -6,20 +6,20 @@
 - name: Nginx Configure | Modules | Make sure the nginx status configuration is updated when enabled
   template:
     src: templates/modules/nginx_status.j2
-    dest: "{{nginx_dir}}/sites-available/nginx_status"
+    dest: "{{ nginx_dir }}/sites-available/nginx_status"
     owner: root
     group: root
     mode: 0644
   notify:
     - reload nginx
-  when: nginx_modules.http_stub_status_module is defined and ( nginx_modules.http_stub_status_module == true or nginx_modules.http_stub_status_module == 'True' )
+  when: "{{ nginx_modules.http_stub_status_module is defined and ( nginx_modules.http_stub_status_module == true or nginx_modules.http_stub_status_module == 'True' ) }}"
 
 - name: Nginx Configure | Modules | Make sure the nginx status configuration is removed when disabled
   file:
-    path: "{{nginx_dir}}/sites-available/nginx_status"
+    path: "{{ nginx_dir }}/sites-available/nginx_status"
     state: absent
   notify:
     - reload nginx
-  when: nginx_modules.http_stub_status_module is not defined or nginx_modules.http_stub_status_module == false or nginx_modules.http_stub_status_module == 'False'
+  when: "{{ nginx_modules.http_stub_status_module is not defined or nginx_modules.http_stub_status_module == false or nginx_modules.http_stub_status_module == 'False' }}"
 
 

--- a/tasks/modules_configure/naxsi_module.yml
+++ b/tasks/modules_configure/naxsi_module.yml
@@ -2,15 +2,15 @@
 - name: Nginx Configure | Modules | Make sure the naxsi_module configuration is up to date when enabled
   copy:
     src: files/naxsi_core.rules
-    dest: "{{nginx_dir}}/naxsi_core.rules"
+    dest: "{{ nginx_dir }}/naxsi_core.rules"
     owner: root
     group: root
     mode: 0644
-  when: nginx_modules.naxsi_module is defined and ( nginx_modules.naxsi_module == true or nginx_modules.naxsi_module == 'True' )
+  when: "{{ nginx_modules.naxsi_module is defined and ( nginx_modules.naxsi_module == true or nginx_modules.naxsi_module == 'True' ) }}"
 
 - name: Nginx Configure | Modules | Make sure the naxsi_module configuration is removed when disabled
   file:
-    path: "{{nginx_dir}}/naxsi_core.rules"
+    path: "{{ nginx_dir }}/naxsi_core.rules"
     state: absent
-  when: nginx_modules.naxsi_module is not defined or nginx_modules.naxsi_module == false or nginx_modules.naxsi_module == 'False'
+  when: "{{ nginx_modules.naxsi_module is not defined or nginx_modules.naxsi_module == false or nginx_modules.naxsi_module == 'False' }}"
 

--- a/tasks/modules_configure/passenger_module.yml
+++ b/tasks/modules_configure/passenger_module.yml
@@ -2,20 +2,20 @@
 - name: Nginx Configure | Modules | Create Passenger config file when enabled
   template:
     src: templates/modules/passenger_conf.j2
-    dest: "{{nginx_dir}}/conf.d/passenger.conf"
+    dest: "{{ nginx_dir }}/conf.d/passenger.conf"
     owner: root
     group: root
     mode: 0644
   notify:
     - reload nginx
-  when: nginx_modules.passenger_module is defined and ( nginx_modules.passenger_module == true or nginx_modules.passenger_module == 'True' )
+  when: "{{ nginx_modules.passenger_module is defined and ( nginx_modules.passenger_module == true or nginx_modules.passenger_module == 'True' ) }}"
 
 - name: Nginx Configure | Modules | Remove Passenger config file when disabled
   file:
-    path: "{{nginx_dir}}/conf.d/passenger.conf"
+    path: "{{ nginx_dir }}/conf.d/passenger.conf"
     state: absent
   notify:
     - reload nginx
-  when: nginx_modules.passenger_module is not defined or nginx_modules.passenger_module == false or nginx_modules.passenger_module == 'False'
+  when: "{{ nginx_modules.passenger_module is not defined or nginx_modules.passenger_module == false or nginx_modules.passenger_module == 'False' }}"
 
 

--- a/tasks/modules_configure/upload_progress_module.yml
+++ b/tasks/modules_configure/upload_progress_module.yml
@@ -2,15 +2,15 @@
 - name: Nginx Configure | Modules | Make sure the upload_progress_module configuration is updated when enabled
   template:
     src: templates/modules/upload_progress.j2
-    dest: "{{nginx_dir}}/sites-available/upload_progress"
+    dest: "{{ nginx_dir }}/sites-available/upload_progress"
     owner: root
     group: root
     mode: 0644
-  when: nginx_modules.upload_progress_module is defined and ( nginx_modules.upload_progress_module == true or nginx_modules.upload_progress_module == 'True' )
+  when: "{{ nginx_modules.upload_progress_module is defined and ( nginx_modules.upload_progress_module == true or nginx_modules.upload_progress_module == 'True' ) }}"
 
 - name: Nginx Configure | Modules | Make sure the upload_progress_module configuration is removed when disabled
   file:
-    path: "{{nginx_dir}}/sites-available/upload_progress"
+    path: "{{ nginx_dir }}/sites-available/upload_progress"
     state: absent
-  when: nginx_modules.upload_progress_module is not defined or nginx_modules.upload_progress_module == false or nginx_modules.upload_progress_module == 'False'
+  when: "{{ nginx_modules.upload_progress_module is not defined or nginx_modules.upload_progress_module == false or nginx_modules.upload_progress_module == 'False' }}"
 

--- a/tasks/modules_install.yml
+++ b/tasks/modules_install.yml
@@ -2,48 +2,48 @@
 # file: nginx/tasks/modules_install.yml
 
 - include: modules_install/http_stub_status_module.yml
-  when: nginx_modules.http_stub_status_module is defined and ( nginx_modules.http_stub_status_module == true or nginx_modules.http_stub_status_module == 'True' )
+  when: "{{ nginx_modules.http_stub_status_module is defined and ( nginx_modules.http_stub_status_module == true or nginx_modules.http_stub_status_module == 'True' ) }}"
 
 - include: modules_install/http_ssl_module.yml
-  when: nginx_modules.http_ssl_module is defined and ( nginx_modules.http_ssl_module == true or nginx_modules.http_ssl_module == 'True' )
+  when: "{{ nginx_modules.http_ssl_module is defined and ( nginx_modules.http_ssl_module == true or nginx_modules.http_ssl_module == 'True' ) }}"
 
 - include: modules_install/http_gzip_static_module.yml
-  when: nginx_modules.http_gzip_static_module is defined and ( nginx_modules.http_gzip_static_module == true or nginx_modules.http_gzip_static_module == 'True' )
+  when: "{{ nginx_modules.http_gzip_static_module is defined and ( nginx_modules.http_gzip_static_module == true or nginx_modules.http_gzip_static_module == 'True' ) }}"
 
 - include: modules_install/upload_progress_module.yml
-  when: nginx_modules.upload_progress_module is defined and ( nginx_modules.upload_progress_module == true or  nginx_modules.upload_progress_module == 'True' )
+  when: "{{ nginx_modules.upload_progress_module is defined and ( nginx_modules.upload_progress_module == true or  nginx_modules.upload_progress_module == 'True' ) }}"
 
 - include: modules_install/headers_more_module.yml
-  when: nginx_modules.headers_more_module is defined and ( nginx_modules.headers_more_module == true or nginx_modules.headers_more_module == 'True' )
+  when: "{{ nginx_modules.headers_more_module is defined and ( nginx_modules.headers_more_module == true or nginx_modules.headers_more_module == 'True' ) }}"
 
 - include: modules_install/http_auth_request_module.yml
-  when: nginx_modules.http_auth_request_module is defined and ( nginx_modules.http_auth_request_module == true or nginx_modules.http_auth_request_module == 'True' )
+  when: "{{ nginx_modules.http_auth_request_module is defined and ( nginx_modules.http_auth_request_module == true or nginx_modules.http_auth_request_module == 'True' ) }}"
 
 - include: modules_install/http_echo_module.yml
-  when: nginx_modules.http_echo_module is defined and ( nginx_modules.http_echo_module == true or nginx_modules.http_echo_module == 'True' )
+  when: "{{ nginx_modules.http_echo_module is defined and ( nginx_modules.http_echo_module == true or nginx_modules.http_echo_module == 'True' ) }}"
 
 - include: modules_install/google_perftools_module.yml
-  when: nginx_modules.google_perftools_module is defined and ( nginx_modules.google_perftools_module == true or nginx_modules.google_perftools_module == 'True' )
+  when: "{{ nginx_modules.google_perftools_module is defined and ( nginx_modules.google_perftools_module == true or nginx_modules.google_perftools_module == 'True' ) }}"
 
 - include: modules_install/ipv6_module.yml
-  when: nginx_modules.ipv6_module is defined and ( nginx_modules.ipv6_module == true or nginx_modules.ipv6_module == 'True' )
+  when: "{{ nginx_modules.ipv6_module is defined and ( nginx_modules.ipv6_module == true or nginx_modules.ipv6_module == 'True' ) }}"
 
 - include: modules_install/http_realip_module.yml
-  when: nginx_modules.http_realip_module is defined and ( nginx_modules.http_realip_module == true or  nginx_modules.http_realip_module == 'True' )
+  when: "{{ nginx_modules.http_realip_module is defined and ( nginx_modules.http_realip_module == true or  nginx_modules.http_realip_module == 'True' ) }}"
 
 - include: modules_install/naxsi_module.yml
-  when: nginx_modules.naxsi_module is defined and ( nginx_modules.naxsi_module == true or nginx_modules.naxsi_module == 'True' )
+  when: "{{ nginx_modules.naxsi_module is defined and ( nginx_modules.naxsi_module == true or nginx_modules.naxsi_module == 'True' ) }}"
 
 - include: modules_install/ngx_http_sub_module.yml
-  when: nginx_modules.ngx_http_sub_module is defined and ( nginx_modules.ngx_http_sub_module == true or nginx_modules.ngx_http_sub_module == 'True' )
+  when: "{{ nginx_modules.ngx_http_sub_module is defined and ( nginx_modules.ngx_http_sub_module == true or nginx_modules.ngx_http_sub_module == 'True' ) }}"
 
 - include: modules_install/ngx_pagespeed_module.yml
-  when: nginx_modules.ngx_pagespeed_module is defined and ( nginx_modules.ngx_pagespeed_module == true or nginx_modules.ngx_pagespeed_module == 'True' )
+  when: "{{ nginx_modules.ngx_pagespeed_module is defined and ( nginx_modules.ngx_pagespeed_module == true or nginx_modules.ngx_pagespeed_module == 'True' ) }}"
 
 - include: modules_install/geoip_module.yml
-  when: nginx_modules.geoip_module is defined and ( nginx_modules.geoip_module == true or  nginx_modules.geoip_module == 'True' )
+  when: "{{ nginx_modules.geoip_module is defined and ( nginx_modules.geoip_module == true or  nginx_modules.geoip_module == 'True' ) }}"
 
 - include: modules_install/passenger_module.yml
-  when: nginx_modules.passenger_module is defined and ( nginx_modules.passenger_module == true or  nginx_modules.passenger_module == 'True' )
+  when: "{{ nginx_modules.passenger_module is defined and ( nginx_modules.passenger_module == true or  nginx_modules.passenger_module == 'True' ) }}"
 
 

--- a/tasks/modules_prepare.yml
+++ b/tasks/modules_prepare.yml
@@ -2,45 +2,45 @@
 # file: nginx/tasks/modules_prepare.yml
 
 - include: modules_prepare/http_stub_status_module.yml
-  when: nginx_modules.http_stub_status_module is defined and ( nginx_modules.http_stub_status_module == true or nginx_modules.http_stub_status_module == 'True' )
+  when: "{{ nginx_modules.http_stub_status_module is defined and ( nginx_modules.http_stub_status_module == true or nginx_modules.http_stub_status_module == 'True' ) }}"
 
 - include: modules_prepare/http_ssl_module.yml
-  when: nginx_modules.http_ssl_module is defined and ( nginx_modules.http_ssl_module == true or nginx_modules.http_ssl_module == 'True' )
+  when: "{{ nginx_modules.http_ssl_module is defined and ( nginx_modules.http_ssl_module == true or nginx_modules.http_ssl_module == 'True' ) }}"
 
 - include: modules_prepare/http_gzip_static_module.yml
-  when: nginx_modules.http_gzip_static_module is defined and ( nginx_modules.http_gzip_static_module == true or nginx_modules.http_gzip_static_module == 'True' )
+  when: "{{ nginx_modules.http_gzip_static_module is defined and ( nginx_modules.http_gzip_static_module == true or nginx_modules.http_gzip_static_module == 'True' ) }}"
 
 - include: modules_prepare/upload_progress_module.yml
-  when: nginx_modules.upload_progress_module is defined and ( nginx_modules.upload_progress_module == true or  nginx_modules.upload_progress_module == 'True' )
+  when: "{{ nginx_modules.upload_progress_module is defined and ( nginx_modules.upload_progress_module == true or  nginx_modules.upload_progress_module == 'True' ) }}"
 
 - include: modules_prepare/headers_more_module.yml
-  when: nginx_modules.headers_more_module is defined and ( nginx_modules.headers_more_module == true or nginx_modules.headers_more_module == 'True' )
+  when: "{{ nginx_modules.headers_more_module is defined and ( nginx_modules.headers_more_module == true or nginx_modules.headers_more_module == 'True' ) }}"
 
 - include: modules_prepare/http_auth_request_module.yml
-  when: nginx_modules.http_auth_request_module is defined and ( nginx_modules.http_auth_request_module == true or nginx_modules.http_auth_request_module == 'True' )
+  when: "{{ nginx_modules.http_auth_request_module is defined and ( nginx_modules.http_auth_request_module == true or nginx_modules.http_auth_request_module == 'True' ) }}"
 
 - include: modules_prepare/http_echo_module.yml
-  when: nginx_modules.http_echo_module is defined and ( nginx_modules.http_echo_module == true or nginx_modules.http_echo_module == 'True' )
+  when: "{{ nginx_modules.http_echo_module is defined and ( nginx_modules.http_echo_module == true or nginx_modules.http_echo_module == 'True' ) }}"
 
 - include: modules_prepare/google_perftools_module.yml
-  when: nginx_modules.google_perftools_module is defined and ( nginx_modules.google_perftools_module == true or nginx_modules.google_perftools_module == 'True' )
+  when: "{{ nginx_modules.google_perftools_module is defined and ( nginx_modules.google_perftools_module == true or nginx_modules.google_perftools_module == 'True' ) }}"
 
 - include: modules_prepare/ipv6_module.yml
-  when: nginx_modules.ipv6_module is defined and ( nginx_modules.ipv6_module == true or nginx_modules.ipv6_module == 'True' )
+  when: "{{ nginx_modules.ipv6_module is defined and ( nginx_modules.ipv6_module == true or nginx_modules.ipv6_module == 'True' ) }}"
 
 - include: modules_prepare/http_realip_module.yml
-  when: nginx_modules.http_realip_module is defined and ( nginx_modules.http_realip_module == true or  nginx_modules.http_realip_module == 'True' )
+  when: "{{ nginx_modules.http_realip_module is defined and ( nginx_modules.http_realip_module == true or  nginx_modules.http_realip_module == 'True' ) }}"
 
 - include: modules_prepare/naxsi_module.yml
-  when: nginx_modules.naxsi_module is defined and ( nginx_modules.naxsi_module == true or nginx_modules.naxsi_module == 'True' )
+  when: "{{ nginx_modules.naxsi_module is defined and ( nginx_modules.naxsi_module == true or nginx_modules.naxsi_module == 'True' ) }}"
 
 - include: modules_prepare/ngx_http_sub_module.yml
-  when: nginx_modules.ngx_http_sub_module is defined and ( nginx_modules.ngx_http_sub == true or nginx_modules.ngx_http_sub_module == 'True' )
+  when: "{{ nginx_modules.ngx_http_sub_module is defined and ( nginx_modules.ngx_http_sub == true or nginx_modules.ngx_http_sub_module == 'True' ) }}"
 
 - include: modules_prepare/ngx_pagespeed_module.yml
-  when: nginx_modules.ngx_pagespeed_module is defined and ( nginx_modules.ngx_pagespeed == true or nginx_modules.ngx_pagespeed_module == 'True' )
+  when: "{{ nginx_modules.ngx_pagespeed_module is defined and ( nginx_modules.ngx_pagespeed == true or nginx_modules.ngx_pagespeed_module == 'True' ) }}"
 
 - include: modules_prepare/passenger_module.yml
-  when: nginx_modules.passenger_module is defined and ( nginx_modules.passenger_module == true or  nginx_modules.passenger_module == 'True' )
+  when: "{{ nginx_modules.passenger_module is defined and ( nginx_modules.passenger_module == true or  nginx_modules.passenger_module == 'True' ) }}"
 
 

--- a/tasks/modules_prepare/passenger_module.yml
+++ b/tasks/modules_prepare/passenger_module.yml
@@ -8,7 +8,7 @@
     name: passenger
     version: "{{nginx_passenger_version}}"
     user_install: no
-  when: passenger_root.stdout == ""
+  when: "{{ passenger_root.stdout == '' }}"
 
 - name: Nginx Prepare | Modules | Get passenger path if not yet defined
   shell: "{% if ruby_location is defined %}{{ ruby_location + '/bin/' }}{% endif %}passenger-config --root || echo '' "
@@ -21,15 +21,15 @@
 - name: Nginx Prepare | Modules | Set Passenger module path
   set_fact:
     nginx_configure_flags: "{{nginx_configure_flags}} --add-module='{{ passenger_root.stdout }}/ext/nginx' "
-  when: passenger_root.stdout != ""
+  when: "{{ passenger_root.stdout != '' }}"
 
 - name: Nginx Prepare | Modules | Set ruby path for Passenger
   set_fact:
     nginx_passenger_ruby: "{% if ruby_location is defined  %}{{ ruby_location + '/bin/ruby'}}{% else %}{{ environment_ruby_path.stdout }}{% endif %}"
-  when: ruby_location is defined or environment_ruby_path.stdout != ""
+  when: "{{ ruby_location is defined or environment_ruby_path.stdout != '' }}"
 
 - name: Nginx Prepare | Modules | Set Passenger root path
   set_fact:
     nginx_passenger_root: "{{ passenger_root.stdout }}"
-  when: passenger_root.stdout != ""
+  when: "{{ passenger_root.stdout != '' }}"
 

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -4,7 +4,7 @@
 
 - name: Nginx Prepare | Make sure the nginx directory exists
   file:
-    path: "{{nginx_dir}}"
+    path: "{{ nginx_dir }}"
     owner: root
     group: root
     mode: 0755
@@ -12,21 +12,21 @@
 
 
 - name: Nginx Prepare | Test for presence of randomized server string
-  shell: "cat '{{nginx_dir}}'/.randomized_server_string || echo ''"
+  shell: "cat '{{ nginx_dir }}'/.randomized_server_string || echo ''"
   register: old_randomized_string_output
-  when: nginx_use_randomized_server_string == true or nginx_use_randomized_server_string == 'True'
+  when: "{{ nginx_use_randomized_server_string == true or nginx_use_randomized_server_string == 'True' }}"
 
 
 - name: Nginx Prepare | Generate randomized server string
   set_fact:
     nginx_randomized_server_string: "{% if old_randomized_string_output.stdout == '' %}{% for i in range(1, 20 + (10|random)) %}{{ ['A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','0','1','2','3','4','5','6','7','8','9']
  | random }}{% endfor %}{% else %}{{old_randomized_string_output.stdout}}{% endif %}"
-  when: nginx_use_randomized_server_string == true or nginx_use_randomized_server_string == 'True'
+  when: "{{ nginx_use_randomized_server_string == true or nginx_use_randomized_server_string == 'True' }}"
 
 
 - name: Nginx Prepare | Save randomized server string
   shell: "echo '{{nginx_randomized_server_string}}' > '{{nginx_dir}}'/.randomized_server_string"
-  when: nginx_use_randomized_server_string == true or nginx_use_randomized_server_string == 'True'
+  when: "{{ nginx_use_randomized_server_string == true or nginx_use_randomized_server_string == 'True' }}"
 
 
 - name: Nginx Prepare | Set preferred server string


### PR DESCRIPTION
Hi.

This role is great, but failing when running on `ansible@2.2.1` because some deprecated notations no longer valid.

For example: `when: variable` should be `when: "{{ variable }}"` since at least `ansible@2.2.1` (maybe since lower, not checked/tested).

This was fixed on given PR.
Please, merge.